### PR TITLE
Multiple Model Support + Preview Image Render and Auto Generated File Structure

### DIFF
--- a/AssetBundles/source/Put your stuff here.txt
+++ b/AssetBundles/source/Put your stuff here.txt
@@ -1,1 +1,5 @@
 Put your stuff in AssetBundles/source/ so the sdk can package them correctly
+
+Any prefab named source.prefab will be ignored
+
+put as many prefabs as you want in this folder

--- a/README.md
+++ b/README.md
@@ -1,12 +1,41 @@
 # BSSDK
-This is the official Banana Shooter SDK for creating custom models.
+This is the unofficial Banana Shooter SDK for creating custom models.
 
-To make sure your custom models will be loaded correctly you will have to make sure your .unity3d files name are source.unity3d, otherwise the game wont load it, also you have to create a config.json along with it, the config.json should look like this
+~~To make sure your custom models will be loaded correctly you will have to make sure your .unity3d files name are source.unity3d, otherwise the game wont load it, also you have to create a config.json along with it, the config.json should look like this~~
 
+This revision of the Banana Shooter SDK can produce multiple assets at the same time. Put as many prefabs as you want in the AssetBundles/Source directory. Make sure the prefabs render in a unity universal render pipeline project (URP).
+
+
+The Program will now produce folders for each prefab as well as, the source.unity3d for the prefab, a preview png image, and a config.json.
+
+# Modification Ideology 
+# # Multiple Prefabs
+All folders in the AssetBundles Directory are packed into separate unity3d files, The source folder is named as such because Banana Shooter needs a source.unity3d. To recreate this I move each prefab into directories named after the prefab, then rename each prefab to model.prefab. After this the assets are packed and put into the output folder. After each file is packed. I move each .unity3d into folders named after the pack and rename the .unity3d file. ie modelABC.unity3d -> /modelABC/source.unity3d.
+# # Config Creation
+In the previous steps in the portion of the script that moves the .unity3d(s) the file name is also used to create the config.json file in the following format
+# # # Config Format
 ```json
 {
   "name" : "your models name or whatever you want to show in the game"
 }
 ```
+# # Image Generation
+To crate the preview images I used the unity Asset Preview. There is a lot of funky coding mumbo jumbo that allows the asset to be loaded and then for the preview to be rendered and saved as a texture2d then to be converted to a png, read through it if you want but im still confused on how it all works (multiple temporary files and conversion steps)
 
-Tutorials will be added later
+
+# Know Issues
+# # AssetBundle Build Failed!
+1. Press the build button again,
+2. If that doesn't work, check your prefabs, delete everything in the output folder and delete everything in the AssetBundle folder other than source and source.meta (you need to delete them in unity so that the folders aren't reconstructed in unity from the meta data files), if error persists, well darn idk man, try step 1 or 2 again
+# # Created models are locked to the origin X,Y position
+Remove these functions in this order
+1. Animations
+2. Constant Applied forces
+3. Rigid body position locks  
+# # Scripts Do nothing
+I haven't figured out how to fix this yet
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -9,30 +9,30 @@ This revision of the Banana Shooter SDK can produce multiple assets at the same 
 The Program will now produce folders for each prefab as well as, the source.unity3d for the prefab, a preview png image, and a config.json.
 
 # Modification Ideology 
-# # Multiple Prefabs
+## Multiple Prefabs
 All folders in the AssetBundles Directory are packed into separate unity3d files, The source folder is named as such because Banana Shooter needs a source.unity3d. To recreate this I move each prefab into directories named after the prefab, then rename each prefab to model.prefab. After this the assets are packed and put into the output folder. After each file is packed. I move each .unity3d into folders named after the pack and rename the .unity3d file. ie modelABC.unity3d -> /modelABC/source.unity3d.
-# # Config Creation
+## Config Creation
 In the previous steps in the portion of the script that moves the .unity3d(s) the file name is also used to create the config.json file in the following format
-# # # Config Format
+### Config Format
 ```json
 {
   "name" : "your models name or whatever you want to show in the game"
 }
 ```
-# # Image Generation
+## Image Generation
 To crate the preview images I used the unity Asset Preview. There is a lot of funky coding mumbo jumbo that allows the asset to be loaded and then for the preview to be rendered and saved as a texture2d then to be converted to a png, read through it if you want but im still confused on how it all works (multiple temporary files and conversion steps)
 
 
 # Know Issues
-# # AssetBundle Build Failed!
+## AssetBundle Build Failed!
 1. Press the build button again,
 2. If that doesn't work, check your prefabs, delete everything in the output folder and delete everything in the AssetBundle folder other than source and source.meta (you need to delete them in unity so that the folders aren't reconstructed in unity from the meta data files), if error persists, well darn idk man, try step 1 or 2 again
-# # Created models are locked to the origin X,Y position
+## Created models are locked to the origin X,Y position
 Remove these functions in this order
 1. Animations
 2. Constant Applied forces
 3. Rigid body position locks  
-# # Scripts Do nothing
+## Scripts Do nothing
 I haven't figured out how to fix this yet
 
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ To crate the preview images I used the unity Asset Preview. There is a lot of fu
 
 
 # Know Issues
-## AssetBundle Build Failed!
-1. Press the build button again,
-2. If that doesn't work, check your prefabs, delete everything in the output folder and delete everything in the AssetBundle folder other than source and source.meta (you need to delete them in unity so that the folders aren't reconstructed in unity from the meta data files), if error persists, well darn idk man, try step 1 or 2 again
 ## Created models are locked to the origin X,Y position
 Remove these functions in this order
 1. Animations
@@ -35,6 +32,13 @@ Remove these functions in this order
 ## Scripts Do nothing
 I haven't figured out how to fix this yet
 
+
+
+# ChangeLog
+- July 12th: init
+- July 12th: Readme Headers Fixed
+- July 13th: fixed Need to run twice Error
+- July 13th: fixed /source directory from being created
 
 
 

--- a/Scripts/Editor/AssetBundleWindow.cs
+++ b/Scripts/Editor/AssetBundleWindow.cs
@@ -27,10 +27,12 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using UnityEditor;
 using UnityEngine;
 
@@ -71,8 +73,8 @@ namespace Editor
 	    {
 		    // Instantiate undoManager
 		    undoManager = new HOEditorUndoManager( this, "AssetBundleCreator" );
-	    }
-     
+        }
+
 
         void OnGUI()
         {
@@ -195,6 +197,7 @@ namespace Editor
                         if (!Directory.GetDirectories(Application.dataPath + assetBundleFolderLocation).Contains(nameWOext))
                         {
                             Directory.CreateDirectory(Application.dataPath + assetBundleFolderLocation + "/" + nameWOext);
+                            //File.Create(Application.dataPath + assetBundleFolderLocation + "/" + nameWOext + ".meta");
                         }
                         // move file
                         File.Copy(asset, Application.dataPath + assetBundleFolderLocation + "/" + nameWOext + "/" + "model" + ".prefab", true);
@@ -214,7 +217,8 @@ namespace Editor
                     }*/
                 }
 
-
+                //reload asset directory
+                AssetDatabase.Refresh();
 
                 if (!CreateAssetBundles.ExportAssetBundleFolders(this))
                 {
@@ -252,7 +256,9 @@ namespace Editor
                             //Create images
                             try
                             {
-                                File.WriteAllBytes(Application.dataPath + exportLocation + name + "/preview.png", imgPreviews[name]);
+                                if (!name.Equals("source")) { 
+                                    File.WriteAllBytes(Application.dataPath + exportLocation + name + "/preview.png", imgPreviews[name]);
+                                }
                             }
                             catch(Exception e)
                             {
@@ -263,6 +269,22 @@ namespace Editor
                     
                     //create config.json files in all directories containing {"name":"directoryName"}
                 }
+
+
+                //Delete temporary folders
+                string[] needToDeleteDirs = Directory.GetDirectories(Application.dataPath + assetBundleFolderLocation);
+                foreach(string dir in needToDeleteDirs)
+                {
+                    if (!dir.EndsWith("/source"))
+                    {
+                        AssetDatabase.DeleteAsset("Assets" + dir.Replace(Application.dataPath,""));
+                        //Directory.Delete(dir);
+                        //File.Delete(dir + ".meta");
+                    }
+                }
+                File.Delete(Application.dataPath + exportLocation + "source/config.json");
+                File.Delete(Application.dataPath + exportLocation + "source/source.unity3d");
+                Directory.Delete(Application.dataPath + exportLocation + "source");
             }
 
             GUILayout.Label("Bundle Versions", EditorStyles.boldLabel);

--- a/Scripts/Editor/AssetBundleWindow.cs
+++ b/Scripts/Editor/AssetBundleWindow.cs
@@ -26,8 +26,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
@@ -51,6 +54,7 @@ namespace Editor
         public bool disableWriteTypeTree = false;
         public bool deterministicAssetBundle = false;
         public bool uncompressedAssetBundle = false;
+        public bool removeVariantText = false;
 	    public bool setLowerCaseName = true;
 	    
         public Dictionary<string, int> bundleVersions = new Dictionary<string, int>();
@@ -85,6 +89,7 @@ namespace Editor
             collectDependencies = EditorGUILayout.Toggle("CollectDependencies", collectDependencies);
             completeAssets = EditorGUILayout.Toggle("CompleteAssets", completeAssets);
             disableWriteTypeTree = EditorGUILayout.Toggle("DisableWriteTypeTree", disableWriteTypeTree);
+            removeVariantText = EditorGUILayout.Toggle("Remove Variant Text", removeVariantText);
             deterministicAssetBundle = EditorGUILayout.Toggle("DeterministicAssetBundle", deterministicAssetBundle);
             uncompressedAssetBundle = EditorGUILayout.Toggle("UncompressedAssetBundle", uncompressedAssetBundle);
             EditorGUILayout.EndToggleGroup();
@@ -112,6 +117,105 @@ namespace Editor
                 {
                     Directory.CreateDirectory(Application.dataPath + exportLocation);
                 }
+
+                //clear output folder
+                System.IO.DirectoryInfo di = new DirectoryInfo(Application.dataPath + exportLocation);
+
+                foreach (FileInfo file in di.GetFiles())
+                {
+                    file.Delete();
+                }
+                foreach (DirectoryInfo dir in di.GetDirectories())
+                {
+                    dir.Delete(true);
+                }
+
+                // create directories for each prefab in the /Assets/AssetBundles Folder
+                string[] assetsInFolder = Directory.GetFiles(Application.dataPath + assetBundleFolderLocation + "/source");
+
+                Dictionary<string, byte[]> imgPreviews = new Dictionary<string, byte[]>();
+
+
+                foreach (string asset in assetsInFolder)
+                {
+                    if (asset.EndsWith(".prefab"))
+                    {
+
+                        // move prefabs and metadata files to their respective folders
+                        // rename all prefabs and metadata files to model (with respective file extension)
+
+
+                        //get new directory name
+                        Regex r = new Regex(@".+[/\\]+");
+                        string nameWOext = r.Replace(asset.Replace(".prefab", ""),""); //remove extension and all previous directories
+                        if (removeVariantText)
+                        {
+                            nameWOext = nameWOext.Replace(" variant", "");
+                        }
+
+                        //Get images 
+                        DirectoryInfo dirInfo = new DirectoryInfo(Application.dataPath + assetBundleFolderLocation + "source");
+                        string thisFileName = Path.GetFileName(asset);
+                        string internalFilePath = "Assets" + assetBundleFolderLocation + dirInfo.Name + "/" + thisFileName;
+                        GameObject prefab = ((GameObject) AssetDatabase.LoadAssetAtPath(internalFilePath, typeof(GameObject)));
+                        //Debug.LogWarning(prefab == null);
+                        //AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(prefab), ImportAssetOptions.ForceUpdate);
+                        EditorUtility.SetDirty(prefab);
+                        Texture2D prefabPreview = AssetPreview.GetAssetPreview(prefab);
+                        //Debug.LogWarning(prefabPreview == null);
+
+                        // Create a temporary RenderTexture of the same size as the texture
+                        RenderTexture tmp = RenderTexture.GetTemporary(
+                                            prefabPreview.width,
+                                            prefabPreview.height,
+                                            0,
+                                            RenderTextureFormat.Default,
+                                            RenderTextureReadWrite.Default);
+                        // Blit the pixels on texture to the RenderTexture
+                        Graphics.Blit(prefabPreview, tmp);
+                        // Backup the currently set RenderTexture
+                        RenderTexture previous = RenderTexture.active;
+                        // Set the current RenderTexture to the temporary one we created
+                        RenderTexture.active = tmp;
+                        // Create a new readable Texture2D to copy the pixels to it
+                        Texture2D myTexture2D = new Texture2D(prefabPreview.width, prefabPreview.height);
+                        // Copy the pixels from the RenderTexture to the new Texture
+                        myTexture2D.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
+                        myTexture2D.Apply();
+                        // Reset the active RenderTexture
+                        RenderTexture.active = previous;
+                        // Release the temporary RenderTexture
+                        RenderTexture.ReleaseTemporary(tmp);
+                        byte[] bytes = myTexture2D.EncodeToPNG();
+                        imgPreviews[nameWOext] = bytes;
+                        imgPreviews[nameWOext.ToLower()] = bytes;
+
+
+
+                        if (!Directory.GetDirectories(Application.dataPath + assetBundleFolderLocation).Contains(nameWOext))
+                        {
+                            Directory.CreateDirectory(Application.dataPath + assetBundleFolderLocation + "/" + nameWOext);
+                        }
+                        // move file
+                        File.Copy(asset, Application.dataPath + assetBundleFolderLocation + "/" + nameWOext + "/" + "model" + ".prefab", true);
+
+                    }
+                    /*else if (asset.EndsWith(".prefab.meta"))
+                    {
+                        Regex r = new Regex(@".+[/\\]+");
+                        string nameWOext = r.Replace(asset.Replace(".prefab.meta", ""), ""); //remove extension and all previous directories
+                        if (!Directory.GetDirectories(Application.dataPath + assetBundleFolderLocation).Contains(nameWOext))
+                        {
+                            Directory.CreateDirectory(Application.dataPath + assetBundleFolderLocation + "/" + nameWOext);
+                        }
+                        // move file
+                        File.Copy(asset, Application.dataPath + assetBundleFolderLocation + "/" + nameWOext + "/" + "model" + ".prefab.meta", true);
+
+                    }*/
+                }
+
+
+
                 if (!CreateAssetBundles.ExportAssetBundleFolders(this))
                 {
                     Debug.LogError("AssetBundle Build Failed! - Please check your settings in the Bundle Creator at Assets->Bundle Creator-> Asset Bundle Creator.");
@@ -126,6 +230,38 @@ namespace Editor
                     CreateAssetBundles.ReadBundleControlFile(Application.dataPath + exportLocation + CreateAssetBundles.bundleControlFileName, bundleVersions);
                     CreateAssetBundles.ReadBundleContentsFile(Application.dataPath + exportLocation + CreateAssetBundles.bundleContentsFileName, bundleContents);
                     ReadBundleFileSizes();
+
+                    //move all .unity3d files into directories named after the title before the .unity3d extension
+                    string[] packsInFolder = Directory.GetFiles(Application.dataPath + exportLocation);
+                    foreach(string file in packsInFolder)
+                    {
+                        if (file.EndsWith(".unity3d"))
+                        {
+                            Regex r = new Regex(@".+[/\\]+");
+                            string name = r.Replace(file.Replace(".unity3d", ""), "");
+
+                            //Create Directory
+                            Directory.CreateDirectory(Application.dataPath + exportLocation + name);
+
+                            //Move unity3d file and rename it to source.unity3d
+                            File.Move(file, Application.dataPath + exportLocation + name + "/source.unity3d");
+
+                            string json = "{\"name\":\"" + name + "\"}";
+                            File.WriteAllText(Application.dataPath + exportLocation + name + "/config.json", json);
+
+                            //Create images
+                            try
+                            {
+                                File.WriteAllBytes(Application.dataPath + exportLocation + name + "/preview.png", imgPreviews[name]);
+                            }
+                            catch(Exception e)
+                            {
+                                Debug.LogWarning(e);
+                            }
+                        }
+                    }
+                    
+                    //create config.json files in all directories containing {"name":"directoryName"}
                 }
             }
 

--- a/Scripts/Editor/CreateAssetBundles.cs
+++ b/Scripts/Editor/CreateAssetBundles.cs
@@ -44,10 +44,10 @@ public class CreateAssetBundles
         {
             bundleVersions = new Dictionary<string, int>();
         }
-		else
-		{
-			bundleVersions.Clear();	
-		}
+        else
+        {
+            bundleVersions.Clear();
+        }
 
         if (File.Exists(path))
         {
@@ -85,10 +85,10 @@ public class CreateAssetBundles
         {
             bundleContents = new Dictionary<string, List<string>>();
         }
-		else
-		{
-			bundleContents.Clear();	
-		}
+        else
+        {
+            bundleContents.Clear();
+        }
         if (File.Exists(path))
         {
             StreamReader streamReader = new StreamReader(path);
@@ -144,7 +144,7 @@ public class CreateAssetBundles
         StreamWriter streamWriter = new StreamWriter(path);
         foreach (KeyValuePair<string, List<string>> asset in bundleContents)
         {
-            if(File.Exists(exportPath + asset.Key))
+            if (File.Exists(exportPath + asset.Key))
             {
                 //For readability in the txt file
                 streamWriter.WriteLine("BundleName:" + asset.Key);
@@ -183,7 +183,7 @@ public class CreateAssetBundles
         //Read and parse the contents file
         ReadBundleContentsFile(path + bundleContentsFileName, bundleContents);
 
-		//Check if the directory exist
+        //Check if the directory exist
         if (!Directory.Exists(Application.dataPath + assetBundleFolderLocation))
         {
             Debug.LogError("Specified 'AssetBundles folder' does not exist! Open Assets->Bundle Creator->Asset Bundle Creator to correct it");
@@ -199,12 +199,12 @@ public class CreateAssetBundles
 
             //if the user has specified a build target, add a prefix to the bundle name
             string bundleName = "";
-			string directoryName = dirInfo.Name;
-			if(thisWindow.setLowerCaseName)
-			{
-				directoryName = directoryName.ToLower();
-			}
-			
+            string directoryName = dirInfo.Name;
+            if (thisWindow.setLowerCaseName)
+            {
+                directoryName = directoryName.ToLower();
+            }
+
             if (!thisWindow.optionalSettings)
             {
                 bundleName = directoryName + thisWindow.bundleFileExtension;
@@ -234,7 +234,7 @@ public class CreateAssetBundles
                 else if (!asset.EndsWith(".meta"))
                 {
                     //toInclude.AddRange(AssetDatabase.LoadAllAssetsAtPath(assetBundleFolderLocation + dirInfo.Name + "/" + thisFileName));
-					string internalFilePath = "Assets" + assetBundleFolderLocation + dirInfo.Name + "/" + thisFileName;
+                    string internalFilePath = "Assets" + assetBundleFolderLocation + dirInfo.Name + "/" + thisFileName;
                     toInclude.Add((Object)AssetDatabase.LoadAssetAtPath(internalFilePath, typeof(Object)));
                     assetListInFolder.Add(thisFileName);
                 }
@@ -299,11 +299,11 @@ public class CreateAssetBundles
     public static bool BuildAssetBundle(AssetBundleWindow thisWindow, List<Object> toInclude, string bundlePath)
     {
         BuildAssetBundleOptions buildAssetOptions = 0;
-        if(thisWindow.buildAssetBundleOptions)
+        if (thisWindow.buildAssetBundleOptions)
         {
-            if(thisWindow.collectDependencies)
+            if (thisWindow.collectDependencies)
             {
-                if(buildAssetOptions == 0)
+                if (buildAssetOptions == 0)
                 {
                     buildAssetOptions = BuildAssetBundleOptions.CollectDependencies;
                 }
@@ -312,9 +312,9 @@ public class CreateAssetBundles
                     buildAssetOptions |= BuildAssetBundleOptions.CollectDependencies;
                 }
             }
-            if(thisWindow.completeAssets)
+            if (thisWindow.completeAssets)
             {
-                if(buildAssetOptions == 0)
+                if (buildAssetOptions == 0)
                 {
                     buildAssetOptions = BuildAssetBundleOptions.CompleteAssets;
                 }
@@ -323,9 +323,9 @@ public class CreateAssetBundles
                     buildAssetOptions |= BuildAssetBundleOptions.CompleteAssets;
                 }
             }
-            if(thisWindow.disableWriteTypeTree)
+            if (thisWindow.disableWriteTypeTree)
             {
-                if(buildAssetOptions == 0)
+                if (buildAssetOptions == 0)
                 {
                     buildAssetOptions = BuildAssetBundleOptions.DisableWriteTypeTree;
                 }
@@ -334,9 +334,9 @@ public class CreateAssetBundles
                     buildAssetOptions |= BuildAssetBundleOptions.DisableWriteTypeTree;
                 }
             }
-            if(thisWindow.deterministicAssetBundle)
+            if (thisWindow.deterministicAssetBundle)
             {
-                if(buildAssetOptions == 0)
+                if (buildAssetOptions == 0)
                 {
                     buildAssetOptions = BuildAssetBundleOptions.DeterministicAssetBundle;
                 }
@@ -345,9 +345,9 @@ public class CreateAssetBundles
                     buildAssetOptions |= BuildAssetBundleOptions.DeterministicAssetBundle;
                 }
             }
-            if(thisWindow.uncompressedAssetBundle)
+            if (thisWindow.uncompressedAssetBundle)
             {
-                if(buildAssetOptions == 0)
+                if (buildAssetOptions == 0)
                 {
                     buildAssetOptions = BuildAssetBundleOptions.UncompressedAssetBundle;
                 }
@@ -368,28 +368,28 @@ public class CreateAssetBundles
         }
         else
         {
-              if (buildAssetOptions == 0) //If it's still zero, set default values
-              {
-                  Debug.LogWarning("No BuildAssetBundleOptions are set, reverting back to dependency tracking. If you want no dependency tracking uncheck the 'BuildAssetBundleOptions' && 'Optional Settings' toggles all together");
-                  buildAssetOptions = BuildAssetBundleOptions.CollectDependencies | BuildAssetBundleOptions.CompleteAssets;
-				  thisWindow.buildAssetBundleOptions = true;
-                  thisWindow.collectDependencies = true;
-                  thisWindow.completeAssets = true;
-              }
-              if (thisWindow.optionalSettings) //Support for different build targets
-              {
-                  if (!BuildPipeline.BuildAssetBundle(null, toInclude.ToArray(), bundlePath, buildAssetOptions, thisWindow.buildTarget))
-                  {
-                      return false;
-                  }
-              }
-              else
-              {
-                  if (!BuildPipeline.BuildAssetBundle(null, toInclude.ToArray(), bundlePath, buildAssetOptions, BuildTarget.StandaloneWindows64))
-                  {
-                      return false;
-                  }
-              }
+            if (buildAssetOptions == 0) //If it's still zero, set default values
+            {
+                Debug.LogWarning("No BuildAssetBundleOptions are set, reverting back to dependency tracking. If you want no dependency tracking uncheck the 'BuildAssetBundleOptions' && 'Optional Settings' toggles all together");
+                buildAssetOptions = BuildAssetBundleOptions.CollectDependencies | BuildAssetBundleOptions.CompleteAssets;
+                thisWindow.buildAssetBundleOptions = true;
+                thisWindow.collectDependencies = true;
+                thisWindow.completeAssets = true;
+            }
+            if (thisWindow.optionalSettings) //Support for different build targets
+            {
+                if (!BuildPipeline.BuildAssetBundle(null, toInclude.ToArray(), bundlePath, buildAssetOptions, thisWindow.buildTarget))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!BuildPipeline.BuildAssetBundle(null, toInclude.ToArray(), bundlePath, buildAssetOptions, BuildTarget.StandaloneWindows64))
+                {
+                    return false;
+                }
+            }
         }
         return true;
     }


### PR DESCRIPTION
Modified the SDK to pack multiple files into their own source.unity3d(s). The basic approach I took was that the SDK already made a .unity3d for each file in the AssetBundles folder in the original case it made source.unity3d because that was what the one folder was called. Looking at this structure, what I did was take all the files inside of the source folder and move them into their own folders, one directory up in the /AssetBundles Directory; with that, the previous code would generate a bunch of _____.unity3d named after the folders. From there, I am able to rename all the .unity3ds to source.unity3d while moving them into their own folders in the output. I also put a config.json with the text to name the object the same as the folder name. During the first process, I also use the unity asset preview renderer to render a preview Texture2d that I convert to a png and store in a hashmap that is later used to put the png in the created output folder and is then renamed to preview.png!


Steps as a list
1. Prefabs are moved into their own folders out of /AssetBundles/source into /AssetBundles/{name of prefab}
2. Prefabs previews are rendered as texture2ds
3. Old Asset bundler Runs
4. Output Objects are moved into their own folders and renamed source.unity3d
5. Configs are created for each folder
6. Texture2ds are associated with folders, converted to pngs then placed in each folder named preview.png

I'll try and make some inline comments in the PR to explain where these steps are happening.